### PR TITLE
Introduce build output directory

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -2,11 +2,12 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <!-- Build to a folder outside the source folders, making it easier to clean. -->
-    <OutDir>$(MSBuildThisFileDirectory)bin\$(Platform)\$(Configuration)\</OutDir>
-    <OutDir Condition="'$(Platform)'=='Win32'">$(MSBuildThisFileDirectory)bin\x86\$(Configuration)\</OutDir>
+    <OutDir>$(MSBuildThisFileDirectory)build\bin\$(Platform)\$(Configuration)\</OutDir>
+    <OutDir Condition="'$(Platform)'=='Win32'">$(MSBuildThisFileDirectory)build\bin\x86\$(Configuration)\</OutDir>
 
     <!-- C++ temp files can be redirected. -->
-    <IntDir>$(MSBuildThisFileDirectory)intermediate\$(MSBuildProjectName)\$(Platform)\$(Configuration)\</IntDir>
+    <IntDir>$(MSBuildThisFileDirectory)build\intermediate\$(MSBuildProjectName)\$(Platform)\$(Configuration)\</IntDir>
+    <IntDir Condition="'$(Platform)'=='Win32'">$(MSBuildThisFileDirectory)build\intermediate\$(MSBuildProjectName)\x86\$(Configuration)\</IntDir>
 
     <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
 
@@ -29,6 +30,7 @@
 
       <!-- Explicit define that all projects are compiled according the C++20 standard -->
       <LanguageStandard>stdcpp20</LanguageStandard>
+      <UseStandardPreprocessor>true</UseStandardPreprocessor> <!-- Needed as stdcpp20 doesn't enable it by default. -->
 
       <!-- To ensure high quality C++ code use Warning level 4 and treat warnings as errors to ensure warnings are fixed promptly. -->
       <WarningLevel>Level4</WarningLevel>
@@ -70,10 +72,9 @@
       <!--
         __cplusplus = Tell MSVC to use the correct value for the __cplusplus macro
         throwingNew = Communicate with the compiler that only the throwing variant of operator new is used.
-        preprocessor = Enable preprocessor conformance mode.
         utf-8 = interpret all source files as UTF-8.
       -->
-      <AdditionalOptions>/Zc:__cplusplus /Zc:throwingNew /Zc:preprocessor /utf-8 %(AdditionalOptions)</AdditionalOptions>
+      <AdditionalOptions>/Zc:__cplusplus /Zc:throwingNew /utf-8 %(AdditionalOptions)</AdditionalOptions>
 
       <!--
         * Windows SDK *
@@ -101,8 +102,6 @@
       <!-- Use by default precompiled headers with the modern name pch.h -->
       <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
       <PrecompiledHeader>Use</PrecompiledHeader>
-
-      <UseStandardPreprocessor>true</UseStandardPreprocessor>
     </ClCompile>
 
     <Link>

--- a/setup/Product.wxs
+++ b/setup/Product.wxs
@@ -31,11 +31,11 @@
     <ComponentGroup Id="ProductComponents">
 
       <Component Id="C_charls_2_x64.dll" Directory="INSTALLFOLDER64">
-        <File Id="F_charls_2_x64.dll" Source="$(var.SolutionDir)..\bin\x64\Release\charls-2-x64.dll" KeyPath="yes" />
+        <File Id="F_charls_2_x64.dll" Source="$(var.SolutionDir)..\build\bin\x64\Release\charls-2-x64.dll" KeyPath="yes" />
       </Component>
 
       <Component Id="C_charls_2_x86.dll" Directory="INSTALLFOLDER">
-        <File Id="F_charls_2_x86.dll" Source="$(var.SolutionDir)..\bin\x86\Release\charls-2-x86.dll" KeyPath="yes" />
+        <File Id="F_charls_2_x86.dll" Source="$(var.SolutionDir)..\build\bin\x86\Release\charls-2-x86.dll" KeyPath="yes" />
       </Component>
 
       <?define GUID_WICPixelFormat2bppGray = "{6fddc324-4e03-4bfe-b185-3d77768dc906}" ?>
@@ -62,7 +62,7 @@
       <?define FileExtension = ".jls" ?>
 
       <Component Id="C_jpegls_wic_codec_64.dll" Directory="INSTALLFOLDER64" Bitness="always64">
-        <File Id="F_jpegls_wic_codec_64.dll" Source="$(var.SolutionDir)..\bin\x64\Release\jpegls-wic-codec.dll" KeyPath="yes" />
+        <File Id="F_jpegls_wic_codec_64.dll" Source="$(var.SolutionDir)..\build\bin\x64\Release\jpegls-wic-codec.dll" KeyPath="yes" />
 
         <?define var.ComServerFileId = "F_jpegls_wic_codec_64.dll" ?>
         <?include wic_registration.wxi ?>
@@ -71,7 +71,7 @@
       </Component>
 
       <Component Id="C_jpegls_wic_codec_86.dll" Directory="INSTALLFOLDER" Bitness="always32">
-        <File Id="F_jpegls_wic_codec_86.dll" Source="$(var.SolutionDir)..\bin\x86\Release\jpegls-wic-codec.dll" KeyPath="yes" />
+        <File Id="F_jpegls_wic_codec_86.dll" Source="$(var.SolutionDir)..\build\bin\x86\Release\jpegls-wic-codec.dll" KeyPath="yes" />
 
         <?define var.ComServerFileId = "F_jpegls_wic_codec_86.dll" ?>
         <?include wic_registration.wxi ?>

--- a/setup/setup.wixproj
+++ b/setup/setup.wixproj
@@ -2,17 +2,17 @@
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Release</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">x64</Platform>
-    <OutputPath>$(MSBuildThisFileDirectory)..\bin\$(Platform)\$(Configuration)\</OutputPath>
-    <IntermediateOutputPath>$(MSBuildThisFileDirectory)..\intermediate\$(MSBuildProjectName)\$(Platform)\$(Configuration)\</IntermediateOutputPath>
+    <OutputPath>$(MSBuildThisFileDirectory)..\build\bin\$(Platform)\$(Configuration)\</OutputPath>
+    <IntermediateOutputPath>$(MSBuildThisFileDirectory)..\build\intermediate\$(MSBuildProjectName)\$(Platform)\$(Configuration)\</IntermediateOutputPath>
     <!-- ICE03 needs to be suppressed the Visual C++ merge module is used. -->
     <!-- ICE80 needs to be suppressed because both 32 and 64-bit components need to be installed. -->
     <SuppressIces>ICE03;ICE80</SuppressIces>
     <CertificateThumbprint Condition="'$(CertificateThumbprint)' == ''">6e78b103da0729369e44004121fb6bf685fec5d8</CertificateThumbprint>
     <TimestampUrl Condition="'$(TimestampUrl)' == ''">http://time.certum.pl/</TimestampUrl>
-    <CodecX64>$(MSBuildThisFileDirectory)..\bin\x64\Release\jpegls-wic-codec.dll</CodecX64>
-    <CodecX86>$(MSBuildThisFileDirectory)..\bin\x86\Release\jpegls-wic-codec.dll</CodecX86>
-    <CharLSX64>$(MSBuildThisFileDirectory)..\bin\x64\Release\charls-2-x64.dll</CharLSX64>
-    <CharLSX86>$(MSBuildThisFileDirectory)..\bin\x86\Release\charls-2-x86.dll</CharLSX86>
+    <CodecX64>$(MSBuildThisFileDirectory)..\build\bin\x64\Release\jpegls-wic-codec.dll</CodecX64>
+    <CodecX86>$(MSBuildThisFileDirectory)..\build\bin\x86\Release\jpegls-wic-codec.dll</CodecX86>
+    <CharLSX64>$(MSBuildThisFileDirectory)..\build\bin\x64\Release\charls-2-x64.dll</CharLSX64>
+    <CharLSX86>$(MSBuildThisFileDirectory)..\build\bin\x86\Release\charls-2-x86.dll</CharLSX86>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|x64' ">
     <DefineConstants>Debug</DefineConstants>


### PR DESCRIPTION
Move the bin and intermediate directory as sub directories to a build directory. This makes it easier to delete the output and alligns with other projects.