### PR TITLE
Use HRESULT instead of winrt::hresult

### DIFF
--- a/src/dllmain.cpp
+++ b/src/dllmain.cpp
@@ -10,7 +10,7 @@
 #include "util.h"
 #include "version.h"
 
-#include <OleCtl.h>
+#include <olectl.h>
 #include <ShlObj.h>
 
 #include <array>

--- a/src/errors.h
+++ b/src/errors.h
@@ -6,28 +6,26 @@
 #include <winerror.h>
 #include <winrt/base.h>
 
-inline constexpr winrt::hresult error_ok{S_OK};
-inline constexpr winrt::hresult error_fail{E_FAIL};
-inline constexpr winrt::hresult error_pointer{E_POINTER};
-inline constexpr winrt::hresult error_no_aggregation{static_cast<winrt::hresult>(CLASS_E_NOAGGREGATION)};
-inline constexpr winrt::hresult error_class_not_available{static_cast<winrt::hresult>(CLASS_E_CLASSNOTAVAILABLE)};
-inline constexpr winrt::hresult error_invalid_argument{static_cast<winrt::hresult>(E_INVALIDARG)};
+inline constexpr HRESULT error_ok{S_OK};
+inline constexpr HRESULT error_fail{E_FAIL};
+inline constexpr HRESULT error_pointer{E_POINTER};
+inline constexpr HRESULT error_no_aggregation{CLASS_E_NOAGGREGATION};
+inline constexpr HRESULT error_class_not_available{CLASS_E_CLASSNOTAVAILABLE};
+inline constexpr HRESULT error_invalid_argument{E_INVALIDARG};
 
 namespace wincodec {
 
-inline constexpr winrt::hresult error_palette_unavailable{static_cast<winrt::hresult>(WINCODEC_ERR_PALETTEUNAVAILABLE)};
-inline constexpr winrt::hresult error_unsupported_operation{static_cast<winrt::hresult>(WINCODEC_ERR_UNSUPPORTEDOPERATION)};
-inline constexpr winrt::hresult error_codec_no_thumbnail{static_cast<winrt::hresult>(WINCODEC_ERR_CODECNOTHUMBNAIL)};
-inline constexpr winrt::hresult error_frame_missing{static_cast<winrt::hresult>(WINCODEC_ERR_FRAMEMISSING)};
-inline constexpr winrt::hresult error_not_initialized{static_cast<winrt::hresult>(WINCODEC_ERR_NOTINITIALIZED)};
-inline constexpr winrt::hresult error_wrong_state{static_cast<winrt::hresult>(WINCODEC_ERR_WRONGSTATE)};
-inline constexpr winrt::hresult error_unsupported_pixel_format{
-    static_cast<winrt::hresult>(WINCODEC_ERR_UNSUPPORTEDPIXELFORMAT)};
-inline constexpr winrt::hresult error_codec_too_many_scan_lines{
-    static_cast<winrt::hresult>(WINCODEC_ERR_CODECTOOMANYSCANLINES)};
-inline constexpr winrt::hresult error_component_not_found{static_cast<winrt::hresult>(WINCODEC_ERR_COMPONENTNOTFOUND)};
-inline constexpr winrt::hresult error_bad_header{static_cast<winrt::hresult>(WINCODEC_ERR_BADHEADER)};
-inline constexpr winrt::hresult error_bad_image{static_cast<winrt::hresult>(WINCODEC_ERR_BADIMAGE)};
+inline constexpr HRESULT error_palette_unavailable{WINCODEC_ERR_PALETTEUNAVAILABLE};
+inline constexpr HRESULT error_unsupported_operation{WINCODEC_ERR_UNSUPPORTEDOPERATION};
+inline constexpr HRESULT error_codec_no_thumbnail{WINCODEC_ERR_CODECNOTHUMBNAIL};
+inline constexpr HRESULT error_frame_missing{WINCODEC_ERR_FRAMEMISSING};
+inline constexpr HRESULT error_not_initialized{WINCODEC_ERR_NOTINITIALIZED};
+inline constexpr HRESULT error_wrong_state{WINCODEC_ERR_WRONGSTATE};
+inline constexpr HRESULT error_unsupported_pixel_format{WINCODEC_ERR_UNSUPPORTEDPIXELFORMAT};
+inline constexpr HRESULT error_codec_too_many_scan_lines{WINCODEC_ERR_CODECTOOMANYSCANLINES};
+inline constexpr HRESULT error_component_not_found{WINCODEC_ERR_COMPONENTNOTFOUND};
+inline constexpr HRESULT error_bad_header{WINCODEC_ERR_BADHEADER};
+inline constexpr HRESULT error_bad_image{WINCODEC_ERR_BADIMAGE};
 
 } // namespace wincodec
 
@@ -35,7 +33,7 @@ template<typename T>
 T* check_in_pointer(_In_ T* pointer)
 {
     if (!pointer)
-        throw_hresult(error_invalid_argument);
+        winrt::throw_hresult(error_invalid_argument);
 
     return pointer;
 }
@@ -44,7 +42,7 @@ template<typename T>
 T* check_out_pointer(T* pointer)
 {
     if (!pointer)
-        throw_hresult(error_pointer);
+        winrt::throw_hresult(error_pointer);
 
     return pointer;
 }

--- a/src/jpegls_bitmap_decoder.cpp
+++ b/src/jpegls_bitmap_decoder.cpp
@@ -142,7 +142,6 @@ public:
         return wincodec::error_palette_unavailable;
     }
 
-    SUPPRESS_FALSE_WARNING_C6101_NEXT_LINE
     HRESULT __stdcall GetMetadataQueryReader(
         [[maybe_unused]] _Outptr_ IWICMetadataQueryReader** metadata_query_reader) noexcept override
     {
@@ -153,7 +152,6 @@ public:
         return wincodec::error_unsupported_operation;
     }
 
-    SUPPRESS_FALSE_WARNING_C6101_NEXT_LINE
     HRESULT __stdcall GetPreview([[maybe_unused]] _Outptr_ IWICBitmapSource** bitmap_source) noexcept override
     {
         TRACE("{} jpegls_bitmap_decoder::GetPreview, bitmap_source={}\n", fmt::ptr(this), fmt::ptr(bitmap_source));
@@ -177,7 +175,6 @@ public:
         return to_hresult();
     }
 
-    SUPPRESS_FALSE_WARNING_C6101_NEXT_LINE
     HRESULT __stdcall GetThumbnail([[maybe_unused]] _Outptr_ IWICBitmapSource** thumbnail) noexcept override
     {
         TRACE("{} jpegls_bitmap_decoder::GetThumbnail, thumbnail={}\n", fmt::ptr(this), fmt::ptr(thumbnail));
@@ -198,7 +195,6 @@ public:
         return to_hresult();
     }
 
-    SUPPRESS_FALSE_WARNING_C6101_NEXT_LINE
     HRESULT __stdcall GetFrame(const uint32_t index, _Outptr_ IWICBitmapFrameDecode** bitmap_frame_decode) noexcept override
     try
     {

--- a/src/jpegls_bitmap_encoder.cpp
+++ b/src/jpegls_bitmap_encoder.cpp
@@ -70,7 +70,6 @@ public:
         return to_hresult();
     }
 
-    SUPPRESS_FALSE_WARNING_C6101_NEXT_LINE
     HRESULT __stdcall CreateNewFrame(_Outptr_ IWICBitmapFrameEncode** bitmap_frame_encode,
                                      IPropertyBag2** encoder_options) noexcept override
     try

--- a/src/jpegls_bitmap_frame_decode.cpp
+++ b/src/jpegls_bitmap_frame_decode.cpp
@@ -185,12 +185,12 @@ jpegls_bitmap_frame_decode::jpegls_bitmap_frame_decode(_In_ IStream* stream, _In
     std::error_code error;
     decoder.read_header(error);
     if (error)
-        throw_hresult(wincodec::error_bad_header);
+        winrt::throw_hresult(wincodec::error_bad_header);
 
     const auto& frame_info{decoder.frame_info()};
     auto pixel_format_info{get_pixel_format(frame_info.bits_per_sample, frame_info.component_count)};
     if (!pixel_format_info)
-        throw_hresult(wincodec::error_unsupported_pixel_format);
+        winrt::throw_hresult(wincodec::error_unsupported_pixel_format);
 
     const auto& [pixel_format, sample_shift] = pixel_format_info.value();
     winrt::com_ptr<IWICBitmap> bitmap;
@@ -209,7 +209,7 @@ jpegls_bitmap_frame_decode::jpegls_bitmap_frame_decode(_In_ IStream* stream, _In
         if (stride < compute_stride(frame_info))
         {
             ASSERT(false);
-            throw_hresult(wincodec::error_bad_image);
+            winrt::throw_hresult(wincodec::error_bad_image);
         }
 
         std::byte* data_buffer;

--- a/src/jpegls_bitmap_frame_encode.h
+++ b/src/jpegls_bitmap_frame_encode.h
@@ -80,7 +80,7 @@ public:
     {
         TRACE("{} jpegls_bitmap_frame_encode::SetResolution.1, dpi_x={}, dpi_y={}\n", fmt::ptr(this), dpi_x, dpi_y);
 
-        check_condition(!(state_ == state::commited), wincodec::error_wrong_state);
+        check_condition(state_ != state::commited, wincodec::error_wrong_state);
         dpi_x_ = dpi_x;
         dpi_y_ = dpi_y;
         dpi_set_ = true;

--- a/src/util.h
+++ b/src/util.h
@@ -21,12 +21,6 @@ extern "C" IMAGE_DOS_HEADER __ImageBase; // NOLINT(bugprone-reserved-identifier)
 
 // The 2 macros below are used to disable false positives. These warnings are too useful to disable them globally.
 
-// A false warning is generated when a type is returned that can converted to a HRESULT but is not a HRESULT.
-// The HRESULT type is tagged with a SAL annotation that indicates when the function returns an error or not.
-// Reported to Microsoft:
-// https://developercommunity.visualstudio.com/content/problem/804429/static-analysis-emits-a-false-positive-c6101-error.html
-#define SUPPRESS_FALSE_WARNING_C6101_NEXT_LINE SUPPRESS_WARNING_NEXT_LINE(6101)
-
 // A false warning is generated when a noexcept methods calls a function that is not marked noexcept.
 // Reported to Microsoft:
 // https://developercommunity.visualstudio.com/content/problem/804372/c26447-false-positive-when-using-stdscoped-lock-ev.html

--- a/test/dllmain_test.cpp
+++ b/test/dllmain_test.cpp
@@ -21,7 +21,7 @@ public:
     {
         const auto class_factory{factory_.get_class_factory(CLSID_JpegLSDecoder)};
 
-        hresult result{class_factory->LockServer(true)};
+        HRESULT result{class_factory->LockServer(true)};
         Assert::AreEqual(error_ok, result);
 
         result = class_factory->LockServer(false);
@@ -32,7 +32,7 @@ public:
     {
         const auto class_factory{factory_.get_class_factory(CLSID_JpegLSEncoder)};
 
-        hresult result{class_factory->LockServer(true)};
+        HRESULT result{class_factory->LockServer(true)};
         Assert::AreEqual(error_ok, result);
 
         result = class_factory->LockServer(false);
@@ -42,7 +42,7 @@ public:
     TEST_METHOD(class_factory_unknown_id) // NOLINT
     {
         com_ptr<IClassFactory> class_factory;
-        const hresult result{factory_.get_class_factory(GUID_VendorTeamCharLS, class_factory)};
+        const HRESULT result{factory_.get_class_factory(GUID_VendorTeamCharLS, class_factory)};
 
         Assert::AreEqual(error_class_not_available, result);
     }
@@ -52,7 +52,7 @@ public:
         const auto class_factory{factory_.get_class_factory(CLSID_JpegLSEncoder)};
 
         WARNING_SUPPRESS_NEXT_LINE(6387) // don't pass nullptr
-        const hresult result{class_factory->CreateInstance(nullptr, GUID_VendorTeamCharLS, nullptr)};
+        const HRESULT result{class_factory->CreateInstance(nullptr, GUID_VendorTeamCharLS, nullptr)};
 
         Assert::AreEqual(error_pointer, result);
     }
@@ -63,7 +63,7 @@ public:
 
         auto* outer{reinterpret_cast<IUnknown*>(1)};
         com_ptr<IWICBitmapDecoder> decoder;
-        const hresult result{class_factory->CreateInstance(outer, IID_PPV_ARGS(decoder.put()))};
+        const HRESULT result{class_factory->CreateInstance(outer, IID_PPV_ARGS(decoder.put()))};
 
         Assert::AreEqual(error_no_aggregation, result);
     }
@@ -73,7 +73,7 @@ public:
         const auto class_factory{factory_.get_class_factory(CLSID_JpegLSDecoder)};
 
         WARNING_SUPPRESS_NEXT_LINE(6387) // don't pass nullptr
-        const hresult result{class_factory->CreateInstance(nullptr, GUID_VendorTeamCharLS, nullptr)};
+        const HRESULT result{class_factory->CreateInstance(nullptr, GUID_VendorTeamCharLS, nullptr)};
 
         Assert::AreEqual(error_pointer, result);
     }
@@ -84,7 +84,7 @@ public:
 
         auto* outer{reinterpret_cast<IUnknown*>(1)};
         com_ptr<IWICBitmapDecoder> decoder;
-        const hresult result{class_factory->CreateInstance(outer, IID_PPV_ARGS(decoder.put()))};
+        const HRESULT result{class_factory->CreateInstance(outer, IID_PPV_ARGS(decoder.put()))};
 
         Assert::AreEqual(error_no_aggregation, result);
     }

--- a/test/jpegls_bitmap_decoder_test.cpp
+++ b/test/jpegls_bitmap_decoder_test.cpp
@@ -19,7 +19,7 @@ public:
     TEST_METHOD(GetContainerFormat) // NOLINT
     {
         GUID container_format;
-        const hresult result{factory_.create_decoder()->GetContainerFormat(&container_format)};
+        const HRESULT result{factory_.create_decoder()->GetContainerFormat(&container_format)};
 
         Assert::AreEqual(error_ok, result);
         Assert::IsTrue(GUID_ContainerFormatJpegLS == container_format);
@@ -28,7 +28,7 @@ public:
     TEST_METHOD(GetContainerFormat_with_nullptr) // NOLINT
     {
         WARNING_SUPPRESS_NEXT_LINE(6387) // don't pass nullptr
-        const hresult result{factory_.create_decoder()->GetContainerFormat(nullptr)};
+        const HRESULT result{factory_.create_decoder()->GetContainerFormat(nullptr)};
 
         Assert::IsTrue(failed(result));
     }
@@ -38,7 +38,7 @@ public:
         const com_ptr decoder{factory_.create_decoder()};
 
         com_ptr<IWICBitmapDecoderInfo> decoder_info;
-        const hresult result{decoder->GetDecoderInfo(decoder_info.put())};
+        const HRESULT result{decoder->GetDecoderInfo(decoder_info.put())};
 
         Assert::IsTrue(result == error_ok || result == wincodec::error_component_not_found);
         if (succeeded(result))
@@ -54,7 +54,7 @@ public:
     TEST_METHOD(GetDecoderInfo_with_nullptr) // NOLINT
     {
         WARNING_SUPPRESS_NEXT_LINE(6387) // don't pass nullptr
-        const hresult result{factory_.create_decoder()->GetDecoderInfo(nullptr)};
+        const HRESULT result{factory_.create_decoder()->GetDecoderInfo(nullptr)};
 
         Assert::IsTrue(failed(result));
     }
@@ -62,7 +62,7 @@ public:
     TEST_METHOD(CopyPalette) // NOLINT
     {
         const com_ptr<IWICPalette> palette;
-        const hresult result{factory_.create_decoder()->CopyPalette(palette.get())};
+        const HRESULT result{factory_.create_decoder()->CopyPalette(palette.get())};
 
         Assert::AreEqual(wincodec::error_palette_unavailable, result);
     }
@@ -70,7 +70,7 @@ public:
     TEST_METHOD(GetMetadataQueryReader) // NOLINT
     {
         com_ptr<IWICMetadataQueryReader> metadata_query_reader;
-        const hresult result{factory_.create_decoder()->GetMetadataQueryReader(metadata_query_reader.put())};
+        const HRESULT result{factory_.create_decoder()->GetMetadataQueryReader(metadata_query_reader.put())};
 
         Assert::AreEqual(wincodec::error_unsupported_operation, result);
     }
@@ -78,7 +78,7 @@ public:
     TEST_METHOD(GetPreview) // NOLINT
     {
         com_ptr<IWICBitmapSource> bitmap_source;
-        const hresult result{factory_.create_decoder()->GetPreview(bitmap_source.put())};
+        const HRESULT result{factory_.create_decoder()->GetPreview(bitmap_source.put())};
 
         Assert::AreEqual(wincodec::error_unsupported_operation, result);
     }
@@ -87,7 +87,7 @@ public:
     {
         com_ptr<IWICColorContext> color_contexts;
         uint32_t actual_count;
-        const hresult result{factory_.create_decoder()->GetColorContexts(1, color_contexts.put(), &actual_count)};
+        const HRESULT result{factory_.create_decoder()->GetColorContexts(1, color_contexts.put(), &actual_count)};
 
         Assert::AreEqual(error_ok, result);
         Assert::AreEqual(0U, actual_count);
@@ -96,7 +96,7 @@ public:
     TEST_METHOD(GetThumbnail) // NOLINT
     {
         com_ptr<IWICBitmapSource> bitmap_source;
-        const hresult result{factory_.create_decoder()->GetThumbnail(bitmap_source.put())};
+        const HRESULT result{factory_.create_decoder()->GetThumbnail(bitmap_source.put())};
 
         Assert::AreEqual(wincodec::error_codec_no_thumbnail, result);
     }
@@ -104,7 +104,7 @@ public:
     TEST_METHOD(GetFrameCount) // NOLINT
     {
         uint32_t frame_count;
-        const hresult result{factory_.create_decoder()->GetFrameCount(&frame_count)};
+        const HRESULT result{factory_.create_decoder()->GetFrameCount(&frame_count)};
 
         Assert::AreEqual(error_ok, result);
         Assert::AreEqual(1U, frame_count);
@@ -113,7 +113,7 @@ public:
     TEST_METHOD(GetFrameCount_count_parameter_is_null) // NOLINT
     {
         WARNING_SUPPRESS_NEXT_LINE(6387) // don't pass nullptr
-        const hresult result{factory_.create_decoder()->GetFrameCount(nullptr)};
+        const HRESULT result{factory_.create_decoder()->GetFrameCount(nullptr)};
 
         Assert::AreEqual(error_pointer, result);
     }
@@ -124,7 +124,7 @@ public:
         stream.attach(SHCreateMemStream(nullptr, 0));
 
         DWORD capability;
-        const hresult result{factory_.create_decoder()->QueryCapability(stream.get(), &capability)};
+        const HRESULT result{factory_.create_decoder()->QueryCapability(stream.get(), &capability)};
 
         Assert::AreEqual(error_ok, result);
         Assert::AreEqual(0UL, capability);
@@ -136,7 +136,7 @@ public:
         check_hresult(
             SHCreateStreamOnFileEx(L"tulips-gray-8bit-512-512.jls", STGM_READ | STGM_SHARE_DENY_WRITE, 0, false, nullptr, stream.put()));
         DWORD capability;
-        const hresult result{factory_.create_decoder()->QueryCapability(stream.get(), &capability)};
+        const HRESULT result{factory_.create_decoder()->QueryCapability(stream.get(), &capability)};
 
         Assert::AreEqual(error_ok, result);
         Assert::AreEqual(static_cast<DWORD>(WICBitmapDecoderCapabilityCanDecodeAllImages), capability);
@@ -145,7 +145,7 @@ public:
     TEST_METHOD(QueryCapability_stream_argument_null) // NOLINT
     {
         DWORD capability;
-        const hresult result{factory_.create_decoder()->QueryCapability(nullptr, &capability)};
+        const HRESULT result{factory_.create_decoder()->QueryCapability(nullptr, &capability)};
 
         Assert::AreEqual(error_invalid_argument, result);
     }
@@ -156,7 +156,7 @@ public:
         stream.attach(SHCreateMemStream(nullptr, 0));
 
         WARNING_SUPPRESS_NEXT_LINE(6387) // don't pass nullptr
-        const hresult result{factory_.create_decoder()->QueryCapability(stream.get(), nullptr)};
+        const HRESULT result{factory_.create_decoder()->QueryCapability(stream.get(), nullptr)};
 
         Assert::AreEqual(error_pointer, result);
     }
@@ -196,7 +196,7 @@ public:
         com_ptr<IStream> stream;
         stream.attach(SHCreateMemStream(nullptr, 0));
 
-        const hresult result{factory_.create_decoder()->Initialize(stream.get(), WICDecodeMetadataCacheOnDemand)};
+        const HRESULT result{factory_.create_decoder()->Initialize(stream.get(), WICDecodeMetadataCacheOnDemand)};
         Assert::AreEqual(error_ok, result);
     }
 
@@ -205,7 +205,7 @@ public:
         com_ptr<IStream> stream;
         stream.attach(SHCreateMemStream(nullptr, 0));
 
-        const hresult result{factory_.create_decoder()->Initialize(stream.get(), WICDecodeMetadataCacheOnLoad)};
+        const HRESULT result{factory_.create_decoder()->Initialize(stream.get(), WICDecodeMetadataCacheOnLoad)};
         Assert::AreEqual(error_ok, result);
     }
 
@@ -215,7 +215,7 @@ public:
         stream.attach(SHCreateMemStream(nullptr, 0));
 
         const com_ptr decoder{factory_.create_decoder()};
-        hresult result{decoder->Initialize(stream.get(), WICDecodeMetadataCacheOnDemand)};
+        HRESULT result{decoder->Initialize(stream.get(), WICDecodeMetadataCacheOnDemand)};
         Assert::AreEqual(error_ok, result);
 
         result = decoder->Initialize(stream.get(), WICDecodeMetadataCacheOnLoad);
@@ -227,7 +227,7 @@ public:
         com_ptr<IStream> stream;
         stream.attach(SHCreateMemStream(nullptr, 0));
 
-        const hresult result{factory_.create_decoder()->Initialize(stream.get(), static_cast<WICDecodeOptions>(4))};
+        const HRESULT result{factory_.create_decoder()->Initialize(stream.get(), static_cast<WICDecodeOptions>(4))};
 
         // Cache options is not used by decoder and by design not validated.
         Assert::AreEqual(error_ok, result);
@@ -235,7 +235,7 @@ public:
 
     TEST_METHOD(Initialize_null_stream) // NOLINT
     {
-        const hresult result{factory_.create_decoder()->Initialize(nullptr, WICDecodeMetadataCacheOnDemand)};
+        const HRESULT result{factory_.create_decoder()->Initialize(nullptr, WICDecodeMetadataCacheOnDemand)};
         Assert::AreEqual(error_invalid_argument, result);
     }
 
@@ -246,7 +246,7 @@ public:
             SHCreateStreamOnFileEx(L"tulips-gray-8bit-512-512.jls", STGM_READ | STGM_SHARE_DENY_WRITE, 0, false, nullptr, stream.put()));
 
         const com_ptr decoder{factory_.create_decoder()};
-        hresult result{decoder->Initialize(stream.get(), WICDecodeMetadataCacheOnDemand)};
+        HRESULT result{decoder->Initialize(stream.get(), WICDecodeMetadataCacheOnDemand)};
         Assert::AreEqual(error_ok, result);
 
         uint32_t frame_count;
@@ -267,7 +267,7 @@ public:
             SHCreateStreamOnFileEx(L"tulips-gray-8bit-512-512.jls", STGM_READ | STGM_SHARE_DENY_WRITE, 0, false, nullptr, stream.put()));
 
         const com_ptr decoder{factory_.create_decoder()};
-        hresult result{decoder->Initialize(stream.get(), WICDecodeMetadataCacheOnDemand)};
+        HRESULT result{decoder->Initialize(stream.get(), WICDecodeMetadataCacheOnDemand)};
         Assert::AreEqual(error_ok, result);
 
         WARNING_SUPPRESS_NEXT_LINE(6387) // don't pass nullptr
@@ -279,7 +279,7 @@ public:
     TEST_METHOD(GetFrame_with_bad_index) // NOLINT
     {
         com_ptr<IWICBitmapFrameDecode> bitmap_frame_decode;
-        const hresult result{factory_.create_decoder()->GetFrame(1, bitmap_frame_decode.put())};
+        const HRESULT result{factory_.create_decoder()->GetFrame(1, bitmap_frame_decode.put())};
 
         Assert::AreEqual(wincodec::error_frame_missing, result);
     }
@@ -287,7 +287,7 @@ public:
     TEST_METHOD(GetFrame_not_initialized) // NOLINT
     {
         com_ptr<IWICBitmapFrameDecode> bitmap_frame_decode;
-        const hresult result{factory_.create_decoder()->GetFrame(0, bitmap_frame_decode.put())};
+        const HRESULT result{factory_.create_decoder()->GetFrame(0, bitmap_frame_decode.put())};
 
         Assert::AreEqual(wincodec::error_not_initialized, result);
     }

--- a/test/jpegls_bitmap_encoder_test.cpp
+++ b/test/jpegls_bitmap_encoder_test.cpp
@@ -81,7 +81,7 @@ public:
         const com_ptr encoder{factory_.create_encoder()};
 
         GUID container_format;
-        const hresult result{encoder->GetContainerFormat(&container_format)};
+        const HRESULT result{encoder->GetContainerFormat(&container_format)};
         Assert::AreEqual(error_ok, result);
         Assert::IsTrue(GUID_ContainerFormatJpegLS == container_format);
     }
@@ -101,7 +101,7 @@ public:
         const com_ptr encoder{factory_.create_encoder()};
 
         com_ptr<IWICBitmapEncoderInfo> encoder_info;
-        const hresult result{encoder->GetEncoderInfo(encoder_info.put())};
+        const HRESULT result{encoder->GetEncoderInfo(encoder_info.put())};
         Assert::IsTrue(result == error_ok || result == wincodec::error_component_not_found);
 
         if (succeeded(result))
@@ -128,7 +128,7 @@ public:
     {
         const com_ptr encoder{factory_.create_encoder()};
 
-        const hresult result{encoder->SetPreview(nullptr)};
+        const HRESULT result{encoder->SetPreview(nullptr)};
         Assert::AreEqual(wincodec::error_unsupported_operation, result);
     }
 
@@ -136,7 +136,7 @@ public:
     {
         const com_ptr encoder{factory_.create_encoder()};
 
-        const hresult result{encoder->SetThumbnail(nullptr)};
+        const HRESULT result{encoder->SetThumbnail(nullptr)};
         Assert::AreEqual(wincodec::error_unsupported_operation, result);
     }
 
@@ -144,7 +144,7 @@ public:
     {
         const com_ptr encoder{factory_.create_encoder()};
 
-        const hresult result{encoder->SetColorContexts(0, nullptr)};
+        const HRESULT result{encoder->SetColorContexts(0, nullptr)};
         Assert::AreEqual(wincodec::error_unsupported_operation, result);
     }
 
@@ -153,7 +153,7 @@ public:
         const com_ptr encoder{factory_.create_encoder()};
 
         com_ptr<IWICMetadataQueryWriter> metadata_query_writer;
-        const hresult result{encoder->GetMetadataQueryWriter(metadata_query_writer.put())};
+        const HRESULT result{encoder->GetMetadataQueryWriter(metadata_query_writer.put())};
         Assert::AreEqual(wincodec::error_unsupported_operation, result);
         Assert::IsNull(metadata_query_writer.get());
     }
@@ -165,7 +165,7 @@ public:
         com_ptr<IWICPalette> palette;
         check_hresult(imaging_factory()->CreatePalette(palette.put()));
 
-        const hresult result{encoder->SetPalette(palette.get())};
+        const HRESULT result{encoder->SetPalette(palette.get())};
         Assert::AreEqual(wincodec::error_unsupported_operation, result);
     }
 
@@ -176,7 +176,7 @@ public:
 
         const com_ptr encoder{factory_.create_encoder()};
 
-        const hresult result{encoder->Initialize(stream.get(), WICBitmapEncoderCacheInMemory)};
+        const HRESULT result{encoder->Initialize(stream.get(), WICBitmapEncoderCacheInMemory)};
         Assert::AreEqual(error_ok, result);
     }
 
@@ -184,7 +184,7 @@ public:
     {
         const com_ptr encoder{factory_.create_encoder()};
 
-        const hresult result{encoder->Initialize(nullptr, WICBitmapEncoderCacheInMemory)};
+        const HRESULT result{encoder->Initialize(nullptr, WICBitmapEncoderCacheInMemory)};
         Assert::AreEqual(error_invalid_argument, result);
     }
 
@@ -195,7 +195,7 @@ public:
 
         const com_ptr encoder{factory_.create_encoder()};
 
-        hresult result{encoder->Initialize(stream.get(), WICBitmapEncoderCacheInMemory)};
+        HRESULT result{encoder->Initialize(stream.get(), WICBitmapEncoderCacheInMemory)};
         Assert::AreEqual(error_ok, result);
 
         result = encoder->Initialize(stream.get(), WICBitmapEncoderCacheInMemory);
@@ -209,7 +209,7 @@ public:
 
         const com_ptr<IWICBitmapEncoder> encoder = factory_.create_encoder();
 
-        hresult result{encoder->Initialize(stream.get(), WICBitmapEncoderCacheInMemory)};
+        HRESULT result{encoder->Initialize(stream.get(), WICBitmapEncoderCacheInMemory)};
         Assert::AreEqual(error_ok, result);
 
         com_ptr<IWICBitmapFrameEncode> frame_encode;
@@ -225,7 +225,7 @@ public:
 
         const com_ptr encoder{factory_.create_encoder()};
 
-        hresult result{encoder->Initialize(stream.get(), WICBitmapEncoderCacheInMemory)};
+        HRESULT result{encoder->Initialize(stream.get(), WICBitmapEncoderCacheInMemory)};
         Assert::AreEqual(error_ok, result);
 
         WARNING_SUPPRESS_NEXT_LINE(6387) // don't pass nullptr
@@ -239,7 +239,7 @@ public:
         const com_ptr<IWICBitmapEncoder> encoder{factory_.create_encoder()};
 
         com_ptr<IWICBitmapFrameEncode> frame_encode;
-        const hresult result{encoder->CreateNewFrame(frame_encode.put(), nullptr)};
+        const HRESULT result{encoder->CreateNewFrame(frame_encode.put(), nullptr)};
         Assert::AreEqual(wincodec::error_not_initialized, result);
     }
 
@@ -247,7 +247,7 @@ public:
     {
         const com_ptr encoder{factory_.create_encoder()};
 
-        const hresult result{encoder->Commit()};
+        const HRESULT result{encoder->Commit()};
         Assert::AreEqual(wincodec::error_not_initialized, result);
     }
 
@@ -258,7 +258,7 @@ public:
 
         const com_ptr encoder{factory_.create_encoder()};
 
-        hresult result{encoder->Initialize(stream.get(), WICBitmapEncoderCacheInMemory)};
+        HRESULT result{encoder->Initialize(stream.get(), WICBitmapEncoderCacheInMemory)};
         Assert::AreEqual(error_ok, result);
 
         result = encoder->Commit();
@@ -287,7 +287,7 @@ public:
                 reinterpret_cast<BYTE*>(anymap_file.image_data().data()), bitmap.put()));
 
             com_ptr<IWICBitmapFrameEncode> frame_encode;
-            hresult result{encoder->CreateNewFrame(frame_encode.put(), nullptr)};
+            HRESULT result{encoder->CreateNewFrame(frame_encode.put(), nullptr)};
             Assert::AreEqual(error_ok, result);
 
             result = frame_encode->Initialize(nullptr);
@@ -345,7 +345,7 @@ public:
     ///reinterpret_cast<BYTE*>(nibble_pixels.data()), bitmap.put()));
 
     ////        com_ptr<IWICBitmapFrameEncode> frame_encode;
-    ////        hresult result = encoder->CreateNewFrame(frame_encode.put(), nullptr);
+    ////        HRESULT result = encoder->CreateNewFrame(frame_encode.put(), nullptr);
     ////        Assert::AreEqual(error_ok, result);
 
     ////        result = frame_encode->Initialize(nullptr);

--- a/test/jpegls_bitmap_frame_decode_test.cpp
+++ b/test/jpegls_bitmap_frame_decode_test.cpp
@@ -33,7 +33,7 @@ public:
         uint32_t width;
         uint32_t height;
 
-        const hresult result{bitmap_frame_decoder->GetSize(&width, &height)};
+        const HRESULT result{bitmap_frame_decoder->GetSize(&width, &height)};
         Assert::AreEqual(error_ok, result);
         Assert::AreEqual(512U, width);
         Assert::AreEqual(512U, height);
@@ -46,7 +46,7 @@ public:
         com_ptr<IWICPalette> palette;
         check_hresult(imaging_factory()->CreatePalette(palette.put()));
 
-        const hresult result{bitmap_frame_decoder->CopyPalette(palette.get())};
+        const HRESULT result{bitmap_frame_decoder->CopyPalette(palette.get())};
         Assert::AreEqual(wincodec::error_palette_unavailable, result);
     }
 
@@ -55,7 +55,7 @@ public:
         const com_ptr bitmap_frame_decoder{create_frame_decoder(L"tulips-gray-8bit-512-512.jls")};
 
         com_ptr<IWICBitmapSource> thumbnail;
-        const hresult result{bitmap_frame_decoder->GetThumbnail(thumbnail.put())};
+        const HRESULT result{bitmap_frame_decoder->GetThumbnail(thumbnail.put())};
         Assert::AreEqual(wincodec::error_codec_no_thumbnail, result);
     }
 
@@ -64,7 +64,7 @@ public:
         const com_ptr bitmap_frame_decoder{create_frame_decoder(L"tulips-gray-8bit-512-512.jls")};
 
         GUID pixel_format;
-        const hresult result{bitmap_frame_decoder->GetPixelFormat(&pixel_format)};
+        const HRESULT result{bitmap_frame_decoder->GetPixelFormat(&pixel_format)};
         Assert::AreEqual(error_ok, result);
         Assert::IsTrue(GUID_WICPixelFormat8bppGray == pixel_format);
     }
@@ -74,7 +74,7 @@ public:
         const com_ptr bitmap_frame_decoder{create_frame_decoder(L"tulips-gray-8bit-512-512.jls")};
 
         WARNING_SUPPRESS_NEXT_LINE(6387)
-            const hresult result {
+        const HRESULT result{
             bitmap_frame_decoder->GetPixelFormat(nullptr)
         };
         Assert::AreEqual(error_invalid_argument, result);
@@ -86,7 +86,7 @@ public:
 
         double dpi_x;
         double dpi_y;
-        const hresult result{bitmap_frame_decoder->GetResolution(&dpi_x, &dpi_y)};
+        const HRESULT result{bitmap_frame_decoder->GetResolution(&dpi_x, &dpi_y)};
         Assert::AreEqual(error_ok, result);
         Assert::AreEqual(96., dpi_x);
         Assert::AreEqual(96., dpi_y);
@@ -97,7 +97,7 @@ public:
         const com_ptr bitmap_frame_decoder{create_frame_decoder(L"tulips-gray-8bit-512-512.jls")};
 
         WARNING_SUPPRESS_NEXT_LINE(6387)
-            const hresult result {
+        const HRESULT result{
             bitmap_frame_decoder->GetResolution(nullptr, nullptr)
         };
         Assert::AreEqual(error_invalid_argument, result);
@@ -108,7 +108,7 @@ public:
         const com_ptr bitmap_frame_decoder{create_frame_decoder(L"tulips-gray-8bit-512-512.jls")};
 
         uint32_t actual_count;
-        hresult result{bitmap_frame_decoder->GetColorContexts(0, nullptr, &actual_count)};
+        HRESULT result{bitmap_frame_decoder->GetColorContexts(0, nullptr, &actual_count)};
         Assert::AreEqual(error_ok, result);
         Assert::AreEqual(0U, actual_count);
 
@@ -124,7 +124,7 @@ public:
         const com_ptr bitmap_frame_decoder{create_frame_decoder(L"tulips-gray-8bit-512-512.jls")};
 
         com_ptr<IWICMetadataQueryReader> metadata_query_reader;
-        const hresult result{bitmap_frame_decoder->GetMetadataQueryReader(metadata_query_reader.put())};
+        const HRESULT result{bitmap_frame_decoder->GetMetadataQueryReader(metadata_query_reader.put())};
         Assert::AreEqual(wincodec::error_unsupported_operation, result);
     }
 
@@ -137,7 +137,7 @@ public:
         check_hresult(bitmap_frame_decoder->GetSize(&width, &height));
         std::vector<std::byte> buffer(static_cast<size_t>(width) * height);
 
-        hresult result{bitmap_frame_decoder->CopyPixels(nullptr, width, static_cast<uint32_t>(buffer.size()),
+        HRESULT result{bitmap_frame_decoder->CopyPixels(nullptr, width, static_cast<uint32_t>(buffer.size()),
                                                         reinterpret_cast<BYTE*>(buffer.data()))};
         Assert::AreEqual(error_ok, result);
 
@@ -184,7 +184,7 @@ public:
         const com_ptr bitmap_frame_decoder{create_frame_decoder(L"4bit-monochrome.jls")};
 
         GUID pixel_format;
-        hresult result{bitmap_frame_decoder->GetPixelFormat(&pixel_format)};
+        HRESULT result{bitmap_frame_decoder->GetPixelFormat(&pixel_format)};
         Assert::AreEqual(error_ok, result);
         Assert::IsTrue(GUID_WICPixelFormat4bppGray == pixel_format);
 
@@ -224,7 +224,7 @@ public:
         check_hresult(bitmap_frame_decoder->GetSize(&width, &height));
         vector<std::byte> buffer(static_cast<size_t>(width) * height);
 
-        const hresult result{copy_pixels(bitmap_frame_decoder.get(), width, buffer)};
+        const HRESULT result{copy_pixels(bitmap_frame_decoder.get(), width, buffer)};
         Assert::AreEqual(error_ok, result);
 
         compare("tulips-gray-8bit-512-512.pgm", buffer);
@@ -240,7 +240,7 @@ public:
         check_hresult(bitmap_frame_decoder->GetSize(&width, &height));
         vector<std::byte> buffer(static_cast<size_t>(width) * height);
 
-        const hresult result{copy_pixels(bitmap_frame_decoder.get(), width, buffer)};
+        const HRESULT result{copy_pixels(bitmap_frame_decoder.get(), width, buffer)};
         Assert::AreEqual(error_ok, result);
 
         compare("8bit_2x2.pgm", buffer);
@@ -255,7 +255,7 @@ private:
         vector<std::byte> buffer(static_cast<size_t>(width) * height);
 
         const uint32_t stride{(width + 15) / 16 * 4};
-        const hresult result{copy_pixels(bitmap_frame_decoder.get(), stride, buffer)};
+        const HRESULT result{copy_pixels(bitmap_frame_decoder.get(), stride, buffer)};
         Assert::AreEqual(error_ok, result);
 
         const std::vector decoded_buffer{unpack_crumbs(buffer.data(), width, height, stride)};

--- a/test/jpegls_bitmap_frame_encode_test.cpp
+++ b/test/jpegls_bitmap_frame_encode_test.cpp
@@ -25,7 +25,7 @@ public:
     {
         const com_ptr bitmap_frame_encoder{create_frame_encoder()};
 
-        const hresult result{bitmap_frame_encoder->Initialize(nullptr)};
+        const HRESULT result{bitmap_frame_encoder->Initialize(nullptr)};
         Assert::AreEqual(error_ok, result);
     }
 
@@ -34,7 +34,7 @@ public:
         const com_ptr bitmap_frame_encoder{create_frame_encoder()};
         check_hresult(bitmap_frame_encoder->Initialize(nullptr));
 
-        const hresult result{bitmap_frame_encoder->Initialize(nullptr)};
+        const HRESULT result{bitmap_frame_encoder->Initialize(nullptr)};
         Assert::AreEqual(wincodec::error_wrong_state, result);
     }
 
@@ -43,7 +43,7 @@ public:
         const com_ptr bitmap_frame_encoder{create_frame_encoder()};
         commit(bitmap_frame_encoder.get());
 
-        const hresult result{bitmap_frame_encoder->Initialize(nullptr)};
+        const HRESULT result{bitmap_frame_encoder->Initialize(nullptr)};
         Assert::AreEqual(wincodec::error_wrong_state, result);
     }
 
@@ -52,7 +52,7 @@ public:
         const com_ptr bitmap_frame_encoder{create_frame_encoder()};
         check_hresult(bitmap_frame_encoder->Initialize(nullptr));
 
-        const hresult result{bitmap_frame_encoder->SetSize(512, 512)};
+        const HRESULT result{bitmap_frame_encoder->SetSize(512, 512)};
         Assert::AreEqual(error_ok, result);
     }
 
@@ -60,7 +60,7 @@ public:
     {
         const com_ptr bitmap_frame_encoder{create_frame_encoder()};
 
-        const hresult result{bitmap_frame_encoder->SetSize(512, 512)};
+        const HRESULT result{bitmap_frame_encoder->SetSize(512, 512)};
         Assert::AreEqual(wincodec::error_wrong_state, result);
     }
 
@@ -69,7 +69,7 @@ public:
         const com_ptr bitmap_frame_encoder{create_frame_encoder()};
         commit(bitmap_frame_encoder.get());
 
-        const hresult result{bitmap_frame_encoder->SetSize(512, 512)};
+        const HRESULT result{bitmap_frame_encoder->SetSize(512, 512)};
         Assert::AreEqual(wincodec::error_wrong_state, result);
     }
 
@@ -78,7 +78,7 @@ public:
         const com_ptr bitmap_frame_encoder{create_frame_encoder()};
         check_hresult(bitmap_frame_encoder->Initialize(nullptr));
 
-        const hresult result{bitmap_frame_encoder->SetResolution(96., 96.)};
+        const HRESULT result{bitmap_frame_encoder->SetResolution(96., 96.)};
         Assert::AreEqual(error_ok, result);
 
         // TODO: extend this test by encode\decode a sample image.
@@ -88,7 +88,7 @@ public:
     {
         const com_ptr bitmap_frame_encoder{create_frame_encoder()};
 
-        const hresult result{bitmap_frame_encoder->SetResolution(96., 96.)};
+        const HRESULT result{bitmap_frame_encoder->SetResolution(96., 96.)};
         Assert::AreEqual(error_ok, result);
     }
 
@@ -97,7 +97,7 @@ public:
         const com_ptr bitmap_frame_encoder{create_frame_encoder()};
         commit(bitmap_frame_encoder.get());
 
-        const hresult result{bitmap_frame_encoder->SetResolution(96., 96.)};
+        const HRESULT result{bitmap_frame_encoder->SetResolution(96., 96.)};
         Assert::AreEqual(wincodec::error_wrong_state, result);
     }
 
@@ -109,7 +109,7 @@ public:
         check_hresult(imaging_factory()->CreateColorContext(color_context.put()));
         array color_contexts{color_context.get()};
 
-        const hresult result{
+        const HRESULT result{
             bitmap_frame_encoder->SetColorContexts(static_cast<UINT>(color_contexts.size()), color_contexts.data())};
         Assert::AreEqual(wincodec::error_unsupported_operation, result);
     }
@@ -119,7 +119,7 @@ public:
         const com_ptr bitmap_frame_encoder{create_frame_encoder()};
 
         com_ptr<IWICMetadataQueryWriter> metadata_query_writer;
-        const hresult result{bitmap_frame_encoder->GetMetadataQueryWriter(metadata_query_writer.put())};
+        const HRESULT result{bitmap_frame_encoder->GetMetadataQueryWriter(metadata_query_writer.put())};
         Assert::AreEqual(wincodec::error_unsupported_operation, result);
         Assert::IsNull(metadata_query_writer.get());
     }
@@ -128,7 +128,7 @@ public:
     {
         const com_ptr bitmap_frame_encoder{create_frame_encoder()};
 
-        const hresult result{bitmap_frame_encoder->SetThumbnail(nullptr)};
+        const HRESULT result{bitmap_frame_encoder->SetThumbnail(nullptr)};
         Assert::AreEqual(wincodec::error_unsupported_operation, result);
     }
 
@@ -139,7 +139,7 @@ public:
         com_ptr<IWICPalette> palette;
         check_hresult(imaging_factory()->CreatePalette(palette.put()));
 
-        const hresult result{bitmap_frame_encoder->SetPalette(palette.get())};
+        const HRESULT result{bitmap_frame_encoder->SetPalette(palette.get())};
         Assert::AreEqual(wincodec::error_palette_unavailable, result);
     }
 
@@ -152,7 +152,7 @@ public:
         for (const auto& format : formats)
         {
             GUID pixel_format{format};
-            const hresult result{bitmap_frame_encoder->SetPixelFormat(&pixel_format)};
+            const HRESULT result{bitmap_frame_encoder->SetPixelFormat(&pixel_format)};
             Assert::AreEqual(error_ok, result);
             Assert::IsTrue(pixel_format == format);
         }
@@ -164,7 +164,7 @@ public:
         check_hresult(bitmap_frame_encoder->Initialize(nullptr));
 
         WARNING_SUPPRESS_NEXT_LINE(6387)
-        const hresult result{bitmap_frame_encoder->SetPixelFormat(nullptr)};
+        const HRESULT result{bitmap_frame_encoder->SetPixelFormat(nullptr)};
         Assert::AreEqual(error_invalid_argument, result);
     }
 
@@ -175,7 +175,7 @@ public:
         WARNING_SUPPRESS_NEXT_LINE(26496) // The variable 'pixel_format' is assigned only once, mark it as const (con.4).
         GUID pixel_format{GUID_WICPixelFormat8bppGray};
 
-        const hresult result{bitmap_frame_encoder->SetPixelFormat(&pixel_format)};
+        const HRESULT result{bitmap_frame_encoder->SetPixelFormat(&pixel_format)};
         Assert::AreEqual(wincodec::error_wrong_state, result);
     }
 
@@ -187,7 +187,7 @@ public:
         WARNING_SUPPRESS_NEXT_LINE(26496) // The variable 'pixel_format' is assigned only once, mark it as const (con.4).
         GUID pixel_format{GUID_WICPixelFormat8bppGray};
 
-        const hresult result{bitmap_frame_encoder->SetPixelFormat(&pixel_format)};
+        const HRESULT result{bitmap_frame_encoder->SetPixelFormat(&pixel_format)};
         Assert::AreEqual(wincodec::error_wrong_state, result);
     }
 
@@ -195,7 +195,7 @@ public:
     {
         const com_ptr bitmap_frame_encoder{create_frame_encoder()};
 
-        const hresult result{bitmap_frame_encoder->Commit()};
+        const HRESULT result{bitmap_frame_encoder->Commit()};
         Assert::AreEqual(wincodec::error_wrong_state, result);
     }
 
@@ -205,7 +205,7 @@ public:
         check_hresult(bitmap_frame_encoder->Initialize(nullptr));
         set_pixel_format(bitmap_frame_encoder.get(), GUID_WICPixelFormat8bppGray);
 
-        const hresult result{bitmap_frame_encoder->Commit()};
+        const HRESULT result{bitmap_frame_encoder->Commit()};
         Assert::AreEqual(wincodec::error_wrong_state, result);
     }
 
@@ -215,7 +215,7 @@ public:
         check_hresult(bitmap_frame_encoder->Initialize(nullptr));
         check_hresult(bitmap_frame_encoder->SetSize(512, 512));
 
-        const hresult result{bitmap_frame_encoder->Commit()};
+        const HRESULT result{bitmap_frame_encoder->Commit()};
         Assert::AreEqual(wincodec::error_wrong_state, result);
     }
 
@@ -228,7 +228,7 @@ public:
         vector<uint8_t> source(512 * 512);
         bitmap_frame_encoder->WritePixels(512, 512, static_cast<UINT>(source.size()), source.data());
 
-        const hresult result{bitmap_frame_encoder->Commit()};
+        const HRESULT result{bitmap_frame_encoder->Commit()};
         Assert::AreEqual(error_ok, result); // TODO: commit should fail.
     }
 

--- a/test/test_stream.h
+++ b/test/test_stream.h
@@ -14,25 +14,31 @@ public:
     {
     }
 
-    SUPPRESS_FALSE_WARNING_C6101_NEXT_LINE
     HRESULT __stdcall Read(_Out_writes_bytes_to_(cb, *pcbRead) void* /*pv*/, _In_ [[maybe_unused]] ULONG cb,
                            _Out_opt_ [[maybe_unused]] ULONG* pcbRead) noexcept override
     {
+        if (pcbRead)
+        {
+            *pcbRead = 0;
+        }
+
         return fail_on_read_ ? error_fail : error_ok;
     }
 
-    SUPPRESS_FALSE_WARNING_C6101_NEXT_LINE
     HRESULT __stdcall Write(_In_reads_bytes_(cb) const void* /*pv*/, _In_ [[maybe_unused]] ULONG cb,
                             _Out_opt_ ULONG* /*pcbWritten*/) noexcept override
     {
         return error_fail;
     }
 
-    SUPPRESS_FALSE_WARNING_C6101_NEXT_LINE
-    HRESULT __stdcall Seek(LARGE_INTEGER /*dlibMove*/, DWORD /*dwOrigin*/,
-                           _Out_opt_ ULARGE_INTEGER* /*plibNewPosition*/) noexcept override
+    HRESULT __stdcall Seek(LARGE_INTEGER, DWORD /*dwOrigin*/, _Out_opt_ ULARGE_INTEGER* new_position) noexcept override
     {
         --fail_on_seek_counter_;
+
+        if (new_position)
+        {
+            new_position->QuadPart = 0;
+        }
 
         return fail_on_seek_counter_ <= 0 ? error_fail : error_ok;
     }
@@ -42,8 +48,7 @@ public:
         return error_fail;
     }
 
-    SUPPRESS_FALSE_WARNING_C6101_NEXT_LINE
-    HRESULT __stdcall CopyTo(_In_ IStream* /*pstm*/, ULARGE_INTEGER /*cb*/, _Out_opt_ ULARGE_INTEGER* /*pcbRead*/,
+    HRESULT __stdcall CopyTo(_In_ IStream*, ULARGE_INTEGER /*cb*/, _Out_opt_ ULARGE_INTEGER* /*pcbRead*/,
                              _Out_opt_ ULARGE_INTEGER* /*pcbWritten*/) noexcept override
     {
         return error_fail;
@@ -70,14 +75,13 @@ public:
         return error_fail;
     }
 
-    SUPPRESS_FALSE_WARNING_C6101_NEXT_LINE
-    HRESULT __stdcall Stat(__RPC__out STATSTG* /*pstatstg*/, DWORD /*grfStatFlag*/) noexcept override
+    HRESULT __stdcall Stat(__RPC__out STATSTG*, DWORD /*grfStatFlag*/) noexcept override
     {
         return error_fail;
     }
 
     SUPPRESS_FALSE_WARNING_C6101_NEXT_LINE
-    HRESULT __stdcall Clone(__RPC__deref_out_opt IStream** /*ppstm*/) noexcept override
+    HRESULT __stdcall Clone(__RPC__deref_out_opt IStream**) noexcept override
     {
         return error_fail;
     }


### PR DESCRIPTION
Using HRESULT prevents the the false C6101 warnings. This false positive has been reported, but is not on the list for a fix.