### PR TITLE
Add Visual Studio 2022 17,6 spelling checker support

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -3,6 +3,11 @@
 
 root = true
 
+[*]
+
+# Spell checker configuration
+spelling_exclusion_path = spelling.dic
+
 [*.{h,cpp}]
 end_of_line = crlf
 charset = utf-8-bom

--- a/spelling.dic
+++ b/spelling.dic
@@ -1,0 +1,4 @@
+﻿jpegls
+﻿Multiframe
+﻿Inproc
+﻿jlsfile


### PR DESCRIPTION
VS 2022 17.6 comes with build in support for a spell checker that can be configured by means of parameters in the .editorconfig file. Configure it and add an initial spelling.dic with words that should be considered valid but are not known to the spell checker.