### PR TITLE
Enable warning C26478: Don't use std::move on constant variables. (es…

### DIFF
--- a/default.ruleset
+++ b/default.ruleset
@@ -7,7 +7,6 @@
     <Rule Id="C26459" Action="None" />
     <Rule Id="C26472" Action="None" />
     <Rule Id="C26474" Action="None" />
-    <Rule Id="C26478" Action="None" />
     <Rule Id="C26481" Action="None" />
     <Rule Id="C26482" Action="None" />
     <Rule Id="C26485" Action="None" />

--- a/default.ruleset.md
+++ b/default.ruleset.md
@@ -24,9 +24,6 @@ gsl::span and pass as a span iterator (stl.1)
 - C26474: No implicit cast  
 **Rationale**: false warnings for GetProcAddress
 
-- C26478: Don't use std::move on constant variables. (es.56).  
-**Rationale**: false warnings when defining local const variables [Visual Studio 2022 17.7.0 Preview 5.0]
-
 - C26481: Do not pass an array as a single pointer.  
 **Rationale**: Many false warnings at locations when std::span cannot be used.
 


### PR DESCRIPTION
….56), fixed in VS 2022 17.8