### PR TITLE
Remove -p:VCToolsVersion=14.38.33130 in CI build pipeline

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,7 +33,7 @@ jobs:
 
       - name: Run build-wrapper
         run: |
-          build-wrapper-win-x86-64 --out-dir ${{ env.BUILD_WRAPPER_OUT_DIR }} msbuild jpegls-wic-codec.sln /t:jpegls-wic-codec:rebuild /p:Configuration="Release" /p:Platform="x64" /p:VCToolsVersion=14.38.33130 /nodeReuse:false
+          build-wrapper-win-x86-64 --out-dir ${{ env.BUILD_WRAPPER_OUT_DIR }} msbuild jpegls-wic-codec.sln /t:jpegls-wic-codec:rebuild /p:Configuration="Release" /p:Platform="x64" /nodeReuse:false
 
       - name: Run sonar-scanner
         env:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -40,7 +40,7 @@ jobs:
       platform: '$(buildPlatform)'
       configuration: '$(buildConfiguration)'
       maximumCpuCount: true
-      msbuildArgs: -p:JPEGLS_WIC_CODEC_PROFILE=true -p:VCToolsVersion=14.38.33130
+      msbuildArgs: -p:JPEGLS_WIC_CODEC_PROFILE=true -p:JPEGLS_WIC_CODEC_ALL_WARNINGS=true
 
   - task: VSTest@2
     inputs:


### PR DESCRIPTION
Due to several issues github\azure decided to only make the latest build tools available. There is no longer a need to explicit control which build tool to use to ensure that the latest one was selected.

Note: enable JPEGLS_WIC_CODEC_ALL_WARNINGS