### PR TITLE
Mark the generated DLL with OLESelfRegister in the StringFileInfo

### DIFF
--- a/src/jpegls-wic-codec.rc
+++ b/src/jpegls-wic-codec.rc
@@ -34,6 +34,7 @@ BEGIN
             VALUE "OriginalFilename", L"jpegls-wic-codec.dll"
             VALUE "ProductName", L"JPEG-LS WIC codec"
             VALUE "ProductVersion", VERSION
+            VALUE "OLESelfRegister", "\0"
         END
     END
     BLOCK "VarFileInfo"

--- a/src/jpegls_bitmap_encoder.cpp
+++ b/src/jpegls_bitmap_encoder.cpp
@@ -191,8 +191,7 @@ struct jpegls_bitmap_encoder : implements<jpegls_bitmap_encoder, IWICBitmapEncod
 
         // Note: the current implementation doesn't write metadata to the JPEG-LS stream.
         //       The SPIFF header can be used to store metadata items.
-        constexpr HRESULT result = wincodec::error_unsupported_operation;
-        return result;
+        return wincodec::error_unsupported_operation;
     }
 
     HRESULT __stdcall SetPalette(_In_ IWICPalette* palette) noexcept override

--- a/test/dllmain_test.cpp
+++ b/test/dllmain_test.cpp
@@ -10,6 +10,7 @@ import guids;
 import util;
 import winrt;
 import "win.h";
+import "std.h";
 
 using namespace winrt;
 using namespace Microsoft::VisualStudio::CppUnitTestFramework;
@@ -88,6 +89,23 @@ public:
         const HRESULT result{class_factory->CreateInstance(outer, IID_PPV_ARGS(decoder.put()))};
 
         Assert::AreEqual(error_no_aggregation, result);
+    }
+
+    TEST_METHOD(marked_for_self_registration) // NOLINT
+    {
+        const wchar_t dll_name[]{L"jpegls-wic-codec.dll"};
+        DWORD not_used;
+        const DWORD size{GetFileVersionInfoSizeEx(FILE_VER_GET_NEUTRAL, dll_name, &not_used)};
+        Assert::IsTrue(size != 0);
+
+        std::vector<std::byte> buffer(size);
+        bool result = GetFileVersionInfoEx(FILE_VER_GET_NEUTRAL, dll_name, 0, size, buffer.data());
+        Assert::IsTrue(result);
+
+        void* value;
+        UINT value_size;
+        result = VerQueryValue(buffer.data(), L"\\StringFileInfo\\000004b0\\OLESelfRegister", &value, &value_size);
+        Assert::IsTrue(result);
     }
 
 private:


### PR DESCRIPTION
The DLL provides the function DllRegisterServer for COM registration. To indicate that is has this method it should also include the value OLESelfRegister in the StringFileInfo