### PR TITLE
Use C++23 std::to_underlying

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -25,6 +25,7 @@ indent_size = 2
 
 [*.{vcxproj,wixproj}]
 indent_size = 2
+build_check.BC0101.severity=none
 
 [*.md]
 trim_trailing_whitespace = false # Ending with 2 spaces is used for layout in Markdown

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -33,6 +33,8 @@
     <AccelerateBuildsInVisualStudio>true</AccelerateBuildsInVisualStudio><!-- Enable faster builds for SDK style projects in Visual Studio 2022 17.5 and newer. -->
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
 
+    <SignOutput Condition="'$(SignOutput)'==''">false</SignOutput>
+
     <_CertificateThumbprint Condition="'$(_CertificateThumbprint)' != ''">$(CertificateThumbprint)</_CertificateThumbprint>
     <_CertificateThumbprint Condition="'$(_CertificateThumbprint)' == ''">b834c6c1d7e0ae8e76cadcf9e2e7a273133a5df6</_CertificateThumbprint>
     <_TimestampUrl Condition="'$(_TimestampUrl)' != ''"> $(TimestampUrl)</_TimestampUrl>

--- a/src/jpegls_bitmap_decoder.cpp
+++ b/src/jpegls_bitmap_decoder.cpp
@@ -1,4 +1,4 @@
-﻿// SPDX-FileCopyrightText: © 2018 Team CharLS
+// SPDX-FileCopyrightText: © 2018 Team CharLS
 // SPDX-License-Identifier: BSD-3-Clause
 
 module;
@@ -90,7 +90,7 @@ struct jpegls_bitmap_decoder : winrt::implements<jpegls_bitmap_decoder, IWICBitm
     try
     {
         TRACE("{} jpegls_bitmap_decoder::Initialize, stream={}, cache_options={}\n", fmt::ptr(this), fmt::ptr(stream),
-              fmt::underlying(cache_options));
+              std::to_underlying(cache_options));
 
         scoped_lock lock{mutex_};
 

--- a/src/jpegls_bitmap_encoder.cpp
+++ b/src/jpegls_bitmap_encoder.cpp
@@ -1,4 +1,4 @@
-﻿// SPDX-FileCopyrightText: © 2019 Team CharLS
+// SPDX-FileCopyrightText: © 2019 Team CharLS
 // SPDX-License-Identifier: BSD-3-Clause
 
 module;
@@ -8,9 +8,9 @@ module;
 module jpegls_bitmap_encoder;
 
 import std;
-import <win.hpp>;
 import winrt;
 import charls;
+import <win.hpp>;
 
 import class_factory;
 import guids;
@@ -23,6 +23,7 @@ using charls::interleave_mode;
 using charls::jpegls_encoder;
 using charls::spiff_color_space;
 using charls::spiff_resolution_units;
+using std::uint32_t;
 using std::vector;
 using winrt::check_hresult;
 using winrt::com_ptr;
@@ -55,7 +56,7 @@ struct jpegls_bitmap_encoder : implements<jpegls_bitmap_encoder, IWICBitmapEncod
     try
     {
         TRACE("{} jpegls_bitmap_encoder::Initialize, stream={}, cache_option={}\n", fmt::ptr(this), fmt::ptr(destination),
-              fmt::underlying(cache_option));
+              std::to_underlying(cache_option));
 
         check_condition(!static_cast<bool>(destination_), wincodec::error_wrong_state);
         destination_.copy_from(check_in_pointer(destination));

--- a/src/jpegls_bitmap_frame_decode.cpp
+++ b/src/jpegls_bitmap_frame_decode.cpp
@@ -1,4 +1,4 @@
-﻿// SPDX-FileCopyrightText: © 2023 Team CharLS
+// SPDX-FileCopyrightText: © 2023 Team CharLS
 // SPDX-License-Identifier: BSD-3-Clause
 
 module;
@@ -190,8 +190,8 @@ void set_resolution(const jpegls_decoder& decoder, IWICBitmap& bitmap)
 {
     if (decoder.spiff_header_has_value())
     {
-        const auto& spiff_header{decoder.spiff_header()};
-        if (spiff_header.vertical_resolution != 0 && spiff_header.horizontal_resolution != 0)
+        if (const auto& spiff_header{decoder.spiff_header()};
+            spiff_header.vertical_resolution != 0 && spiff_header.horizontal_resolution != 0)
         {
             switch (spiff_header.resolution_units)
             {
@@ -262,7 +262,7 @@ jpegls_bitmap_frame_decode::jpegls_bitmap_frame_decode(IStream* stream, IWICImag
         check_hresult(bitmap_lock->GetDataPointer(&data_buffer_size, reinterpret_cast<BYTE**>(&data_buffer)));
         __assume(data_buffer != nullptr);
 
-        if (frame_info.component_count != 1 && decoder.get_interleave_mode() == charls::interleave_mode::none)
+        if (frame_info.component_count != 1 && decoder.get_interleave_mode() == interleave_mode::none)
         {
             const auto planar{decoder.decode<vector<std::byte>>()};
             if (frame_info.bits_per_sample > 8)

--- a/src/util.ixx
+++ b/src/util.ixx
@@ -1,4 +1,4 @@
-﻿// SPDX-FileCopyrightText: © 2019 Team CharLS
+// SPDX-FileCopyrightText: © 2019 Team CharLS
 // SPDX-License-Identifier: BSD-3-Clause
 
 module;
@@ -12,10 +12,12 @@ import winrt;
 import <win.hpp>;
 
 import hresults;
-
 import "macros.hpp";
 
 using std::uint32_t;
+using std::wstring;
+using std::span;
+using winrt::check_win32;
 
 extern "C" IMAGE_DOS_HEADER __ImageBase; // NOLINT(bugprone-reserved-identifier)
 
@@ -32,9 +34,9 @@ static HMODULE get_current_module() noexcept
 }
 
 export [[nodiscard]]
-std::wstring get_module_path()
+wstring get_module_path()
 {
-    std::wstring path(100, L'?');
+    wstring path(100, L'?');
     size_t path_size;
     size_t actual_size;
 
@@ -55,9 +57,9 @@ std::wstring get_module_path()
 }
 
 export [[nodiscard]]
-std::wstring guid_to_string(const GUID& guid)
+wstring guid_to_string(const GUID& guid)
 {
-    std::wstring guid_text;
+    wstring guid_text;
 
     guid_text.resize(39);
     VERIFY(StringFromGUID2(guid, guid_text.data(), static_cast<int>(guid_text.size())) != 0);
@@ -69,7 +71,7 @@ std::wstring guid_to_string(const GUID& guid)
 }
 
 export [[nodiscard]]
-constexpr bool failed(winrt::hresult const result) noexcept
+constexpr bool failed(const winrt::hresult result) noexcept
 {
     return result < 0;
 }
@@ -112,6 +114,8 @@ export __declspec(noinline) HRESULT to_hresult() noexcept
     {
         return error_out_of_memory;
     }
+
+    // Explicit don't catch unexpected exceptions to enforce terminate with a stack trace.
 }
 
 export namespace fmt {
@@ -123,14 +127,6 @@ auto ptr(T p) noexcept -> const void*
 {
     static_assert(std::is_pointer_v<T>);
     return std::bit_cast<const void*>(p);
-}
-
-// Copied from fmtlib as replacement for std::to_underlying (C++23)
-template<typename Enum>
-[[nodiscard]]
-constexpr auto underlying(Enum e) noexcept -> std::underlying_type_t<Enum>
-{
-    return static_cast<std::underlying_type_t<Enum>>(e);
 }
 
 } // namespace fmt
@@ -145,12 +141,11 @@ export void set_value(_Null_terminated_ const wchar_t* sub_key, _Null_terminated
                       _Null_terminated_ const wchar_t* value)
 {
     const auto length{wcslen(value) + 1};
-    winrt::check_win32(
-        RegSetKeyValue(hkey_local_machine, sub_key, value_name, REG_SZ, value,
-                       static_cast<DWORD>(length * sizeof(wchar_t)))); // NOLINT(bugprone-misplaced-widening-cast)
+    check_win32(RegSetKeyValue(hkey_local_machine, sub_key, value_name, REG_SZ, value,
+                               static_cast<DWORD>(length * sizeof(wchar_t)))); // NOLINT(bugprone-misplaced-widening-cast)
 }
 
-export void set_value(const std::wstring& sub_key, _Null_terminated_ const wchar_t* value_name,
+export void set_value(const wstring& sub_key, _Null_terminated_ const wchar_t* value_name,
                       _Null_terminated_ const wchar_t* value)
 {
     set_value(sub_key.c_str(), value_name, value);
@@ -159,27 +154,26 @@ export void set_value(const std::wstring& sub_key, _Null_terminated_ const wchar
 export void set_value(_Null_terminated_ const wchar_t* sub_key, _Null_terminated_ const wchar_t* value_name,
                       const uint32_t value)
 {
-    winrt::check_win32(RegSetKeyValueW(hkey_local_machine, sub_key, value_name, REG_DWORD, &value, sizeof value));
+    check_win32(RegSetKeyValueW(hkey_local_machine, sub_key, value_name, REG_DWORD, &value, sizeof value));
 }
 
-export void set_value(const std::wstring& sub_key, _Null_terminated_ const wchar_t* value_name, const uint32_t value)
+export void set_value(const wstring& sub_key, _Null_terminated_ const wchar_t* value_name, const uint32_t value)
 {
     set_value(sub_key.c_str(), value_name, value);
 }
 
 export void set_value(_Null_terminated_ const wchar_t* sub_key, _Null_terminated_ const wchar_t* value_name,
-                      std::span<const std::byte> values)
+                      const span<const std::byte> values)
 {
-    winrt::check_win32(RegSetKeyValueW(hkey_local_machine, sub_key, value_name, REG_BINARY, values.data(),
-                                       static_cast<DWORD>(values.size())));
+    check_win32(RegSetKeyValueW(hkey_local_machine, sub_key, value_name, REG_BINARY, values.data(),
+                                static_cast<DWORD>(values.size())));
 }
 
-export void set_value(const std::wstring& sub_key, _Null_terminated_ const wchar_t* value_name,
-                      const std::span<const std::byte> values)
+export void set_value(const wstring& sub_key, _Null_terminated_ const wchar_t* value_name,
+                      const span<const std::byte> values)
 {
     set_value(sub_key.c_str(), value_name, values);
 }
-
 
 export [[nodiscard]]
 HRESULT delete_tree(_Null_terminated_ const wchar_t* sub_key) noexcept

--- a/src/winrt.ixx
+++ b/src/winrt.ixx
@@ -3,6 +3,7 @@
 
 module;
 
+// ReSharper disable once CppInconsistentNaming
 #define _CRT_MEMCPY_S_INLINE inline
 
 // ReSharper disable once CppUnusedIncludeDirective

--- a/std-header-units/std-header-units.vcxproj
+++ b/std-header-units/std-header-units.vcxproj
@@ -30,7 +30,6 @@
     <VCProjectVersion>17.0</VCProjectVersion>
     <Keyword>Win32Proj</Keyword>
     <ProjectGuid>{154ad843-e510-4271-a1dc-8eb291482c38}</ProjectGuid>
-    <RootNamespace>stdheaderunits</RootNamespace>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup>


### PR DESCRIPTION
As this project now uses C++23, there is no longer a need to use custom to_underlying