### PR TITLE
chores: Update MS C++ v14 Redistributable 14.50.35719

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 
 ### Changed
 
-- Updated Microsoft Visual C++ 2015-2022 Redistributable to version 14.44.35026
+- Updated Microsoft Visual C++ 2015-2022 Redistributable to version 14.50.35719
 
 ### Fixed
 

--- a/setup/bootstrapper/Bundle.wxs
+++ b/setup/bootstrapper/Bundle.wxs
@@ -63,14 +63,14 @@
         After="REG_ARCH" />
 
     <!-- Visual C++ 2015-2022 Redistributable runtime msi package version -->
-    <Variable Name="VCRUNTIME_VER" Type="version" Value="14.44.35026.0" />
+    <Variable Name="VCRUNTIME_VER" Type="version" Value="14.50.35719.0" />
 
     <Chain>
       <!-- Visual C++ 2015-2022 Redistributable (x86) -->
       <?if $(sys.BUILDARCHSHORT) = "X86" ?>
       <ExePackage
           Id="VC_REDIST_X86"
-          DisplayName="Microsoft Visual C++ 2015-2022 Redistributable (x86) - 14.44.35026"
+          DisplayName="Microsoft Visual C+ v14 Redistributable (x86) - 14.50.35719"
           Cache="remove"
           PerMachine="yes"
           Permanent="yes"
@@ -82,12 +82,12 @@
           UninstallArguments="/uninstall /quiet /norestart">
         <ExePackagePayload
             Name="VC_redist.x86.exe"
-            ProductName="Microsoft Visual C++ 2015-2022 Redistributable (x86) - 14.44.35026"
-            Description="Microsoft Visual C++ 2015-2022 Redistributable (x86) - 14.44.35026"
-            Hash="B2F2F591B9F152E22BCCE7AEDA8692404F05C703EAA12C39A8CE8B7D21615F6C7E18F5C6C92047A33C49BF6C15E8172D6723E31A97B0C0BD89B02A74798766A2"
-            Size="13955160"
-            Version="14.44.35026.0"
-            DownloadUrl="https://download.visualstudio.microsoft.com/download/pr/e4a579e3-91ed-4372-b9bb-f8d821421292/777C541479C07A375DB0DCCEB027C3AE561E77D82F3551127E1032EC0732E6BE/VC_redist.x86.exe" />
+            ProductName="Microsoft Visual C++ v14 Redistributable (x86) - 14.50.35719"
+            Description="Microsoft Visual C++ v14 Redistributable (x86) - 14.50.35719"
+            Hash="A6687EF328597C90093A4278A12A0059496711801D84A40DC730511BADDE3D94199368D57FDC0926D8A3E19D2D2AEEC8FE58337B91CC69AEB4DFA251833CA5A6"
+            Size="6876208"
+            Version="14.50.35719.0"
+            DownloadUrl="https://download.visualstudio.microsoft.com/download/pr/1c82a588-774f-4cd2-930d-9380f7e34e75/E7267C1BDF9237C0B4A28CF027C382B97AA909934F84F1C92D3FB9F04173B33E/VC_redist.x86.exe" />
       </ExePackage>
       <?endif?>
 
@@ -95,7 +95,7 @@
       <?if $(sys.BUILDARCHSHORT) = "X64" ?>
       <ExePackage
           Id="VC_REDIST_X64"
-          DisplayName="Microsoft Visual C++ 2015-2022 Redistributable (x64) - 14.44.35026"
+          DisplayName="Microsoft Visual C++ v14 Redistributable (x64) - 14.50.35719"
           Cache="remove"
           PerMachine="yes"
           Permanent="yes"
@@ -107,12 +107,12 @@
           UninstallArguments="/uninstall /quiet /norestart">
         <ExePackagePayload
             Name="VC_redist.x64.exe"
-            ProductName="Microsoft Visual C++ 2015-2022 Redistributable (x64) - 14.44.35026"
-            Description="Microsoft Visual C++ 2015-2022 Redistributable (x64) - 14.44.35026"
-            Hash="DCF69C56C33EFF62E53991D8CA101B9DF6BE63C071109BFB820753495C31DB4F3441568133BDC10E017BB7816B6EA408419EB283BFE05027DB3B1DEE65C98094"
-            Size="25621584"
-            Version="14.44.35026.0"
-            DownloadUrl="https://download.visualstudio.microsoft.com/download/pr/8b4a3005-316e-40c9-a12c-945109ada384/A8166D0EDCC808B2582C692AB0068BDE695D1398D2012AF708A876CB91A015F4/VC_redist.x64.exe" />
+            ProductName="Microsoft Visual C++ v14 Redistributable (x64) - 14.50.35719"
+            Description="Microsoft Visual C++ v14 Redistributable (x64) - 14.50.35719"
+            Hash="B618F601A1989A696C8EFA0208EFD977A3BFE9A8DF8ACE8FAE9EEF20262240E7EEFCB67CE466FE166BDC606D80D594D2DE80B3B4E530749AAB8E99F5CECD86D4"
+            Size="18558944"
+            Version="14.50.35719.0"
+            DownloadUrl="https://download.visualstudio.microsoft.com/download/pr/6f02464a-5e9b-486d-a506-c99a17db9a83/8995548DFFFCDE7C49987029C764355612BA6850EE09A7B6F0FDDC85BDC5C280/VC_redist.x64.exe" />
       </ExePackage>
       <?endif?>
 
@@ -120,7 +120,7 @@
       <?if $(sys.BUILDARCHSHORT) = "A64" ?>
       <ExePackage
           Id="VC_REDIST_ARM64"
-          DisplayName="Microsoft Visual C++ 2015-2022 Redistributable (Arm64) - 14.44.35026"
+          DisplayName="Microsoft Visual C++ v14 Redistributable (Arm64) - 14.50.35719"
           Cache="remove"
           PerMachine="yes"
           Permanent="yes"
@@ -132,12 +132,12 @@
           UninstallArguments="/uninstall /quiet /norestart">
         <ExePackagePayload
             Name="VC_redist.arm64.exe"
-            ProductName="Microsoft Visual C++ 2022 Redistributable (Arm64) - 14.44.35026"
-            Description="Microsoft Visual C++ 2022 Redistributable (Arm64) - 14.44.35026"
-            Hash="8F8AD7F38F1F84343D2912867AF21FF1498A5028796EB07BC5EDD3A933A43CD333537A5F6ABC7CBC1F6255CA80A44FEBA5A9A16FD78EE3131C34660D2AD11138"
-            Size="11703312"
-            Version="14.44.35026.0"
-            DownloadUrl="https://download.visualstudio.microsoft.com/download/pr/8b4a3005-316e-40c9-a12c-945109ada384/8DC1E6629A9AEA5723791858E2A9127EBB549648D88C3E7AFB224EA09C3D173B/VC_redist.arm64.exe" />
+            ProductName="Microsoft Visual C++ v14 Redistributable (Arm64) - 14.50.35719"
+            Description="Microsoft Visual C++ v14 Redistributable (Arm64) - 14.50.35719"
+            Hash="5DA5D37877DA4FEDF6E50117D3CAE587E2321522C467B2C124EFF2176526C87CB2C415E6A06C7DF14C4ED4A6C296EF646638FB161F5AA52FAE6CC26DD43ADAD6"
+            Size="11740976"
+            Version="14.50.35719.0"
+            DownloadUrl="https://download.visualstudio.microsoft.com/download/pr/1c82a588-774f-4cd2-930d-9380f7e34e75/FCDA7B24413F170BD456052F08AE49FB60AC1638F083AAB7A35AFEB957AEB1D6/VC_redist.arm64.exe" />
       </ExePackage>
       <?endif?>
 

--- a/setup/bootstrapper/Bundle.wxs
+++ b/setup/bootstrapper/Bundle.wxs
@@ -70,7 +70,7 @@
       <?if $(sys.BUILDARCHSHORT) = "X86" ?>
       <ExePackage
           Id="VC_REDIST_X86"
-          DisplayName="Microsoft Visual C+ v14 Redistributable (x86) - 14.50.35719"
+          DisplayName="Microsoft Visual C++ v14 Redistributable (x86) - 14.50.35719"
           Cache="remove"
           PerMachine="yes"
           Permanent="yes"


### PR DESCRIPTION
It is important to install the version that matches the C++ compiler version that is used to build the DLL. (or higher).